### PR TITLE
Add counter of 30x redirects.

### DIFF
--- a/URLResolver.php
+++ b/URLResolver.php
@@ -109,6 +109,8 @@ class URLResolver {
 
 		$url_is_open_graph = false;
 		$url_is_canonical = false;
+                $url_includes_redirect = false;
+                $url_redirect_30x_count = 0;
 
 		$url_results = array();
 		for ($i = 0; $i < $this->max_redirects; $i++) {
@@ -128,6 +130,9 @@ class URLResolver {
 			# Don't allow it to overwrite a true value determined from markup with a false value...
 			if (!$url_result->isOpenGraphURL()) { $url_result->isOpenGraphURL($url_is_open_graph); }
 			if (!$url_result->isCanonicalURL()) { $url_result->isCanonicalURL($url_is_canonical); }
+                        
+                        # Propogate the 30x count
+                        $url_result->redirect30xCount($url_redirect_30x_count);
 
 			# Also print a short status line regarding the URL once it is fetched
 			if ($this->is_debug) {
@@ -188,6 +193,7 @@ class URLResolver {
 			$url = $next_url;
 			$url_is_open_graph = $url_result->redirectTargetIsOpenGraphURL();
 			$url_is_canonical = $url_result->redirectTargetIsCanonicalURL();
+                        $url_redirect_30x_count = $url_result->redirect30xCount();
 		}
 
 		return $this->resolveURLResults($url_results);
@@ -560,6 +566,8 @@ class URLResolverResult {
 	private $redirect_is_open_graph = false;
 	private $redirect_is_canonical = false;
 
+        private $redirect_30x_count = 0;
+        
 	private $failed = false;
 	private $error = false;
 	private $error_message = '';
@@ -580,7 +588,11 @@ class URLResolverResult {
 	public function hasSuccessHTTPStatus() { return ($this->status == 200); }
 
 	# Returns _true_ if the [HTTP status code] for the resolved URL is 301 or 302.
-	public function hasRedirectHTTPStatus() { return ($this->status == 301 || $this->status == 302 || $this->status == 303); }
+	public function hasRedirectHTTPStatus() {
+            $isRedirect = ($this->status == 301 || $this->status == 302 || $this->status == 303);
+            $this->redirect30xCount( $isRedirect );
+            return $isRedirect;
+        }
 
 	# Returns the value of the Content-Type [HTTP header] for the resolved URL.
 	# If header not provided, _null_ is returned. Examples: text/html, image/jpeg, ...
@@ -613,6 +625,12 @@ class URLResolverResult {
 		if (isset($value)) { $this->is_starting_point = $value ? true : false; }
 		return $this->is_starting_point;
 	}
+
+	# Returns number of 30x redirects we've been through
+        public function redirect30xCount($value=null) {
+		if (isset($value)) { $this->redirect_30x_count += $value; }
+		return $this->redirect_30x_count;
+        }
 
 	# Returns true if an error occurred while resolving the URL.
 	# If this returns false, $url_result is guaranteed to have a status code.


### PR DESCRIPTION
I wanted to be able to tell if a URL was redirected due to OpenGraph/Canonical tags ... or if it truly was a redirect.

```php
    $url = $row["Destination URL"];

    // Not Found, until we determine otherwise
    $row["URL Status"] = "Not Found";
    $url_result = $resolver->resolveURL($url);
        
    if ( $url_result->didConnectionFail() ) {
        $row["URL Status"] = "Connection Failure";
    }
    else if ( $url_result->didErrorOccur() ) {
        $row["URL Status"] = "Error Occured";
    }
    else if ( $url_result->getHTTPStatusCode() == "404" ) {
        $row["URL Status"] = "Not Found";
    }
    else if ( $url_result->isStartingURL() ) {
        $row["URL Status"] = "OK";
    }
    else if ( $url_result->redirect30xCount() ) {
        $row["URL Status"] = "Redirect (" . $url_result->redirect30xCount() . " times)";
        $row["Redirect URL"] = $url_result->getURL();
    }
    else {
        $row["URL Status"] = "Not Canonical";
        $row["Canonical URL"] = $url_result->getURL();
    }
```